### PR TITLE
Support Memory{UInt8} and AbstractVector{UInt8} as input.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
 concurrency:

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,8 @@ Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 julia = "1.3"
 
 [extras]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["OffsetArrays", "Test"]

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ CRC-32 checksum.
 crc32(data, crc::UInt32=0x00000000)
 ```
 
-Computes the CRC-32 checksum (ISO 3309, ITU-T V.42, CRC-32-IEEE) of the given `data`, which can be
-an `Array{UInt8}`, a contiguous subarray thereof, or a `String`.  Optionally, you can pass
-a starting `crc` integer to be mixed in with the checksum.  The `crc` parameter
-can be used to compute a checksum on data divided into chunks: performing
+Compute the CRC-32 checksum (ISO 3309, ITU-T V.42, CRC-32-IEEE) of the given `data`, which can be
+an `Array{UInt8}`, a contiguous subarray thereof, an `AbstractVector{UInt8}`, or a `String`.
+Optionally, you can pass a starting `crc` integer to be mixed in with the checksum.
+The `crc` parameter can be used to compute a checksum on data divided into chunks: performing
 `crc32(data2, crc32(data1))` is equivalent to the checksum of `[data1; data2]`.
 
 There is also a method `crc32(io, nb, crc)` to checksum `nb` bytes from

--- a/src/CRC32.jl
+++ b/src/CRC32.jl
@@ -78,8 +78,8 @@ end
 function _crc32(a::AbstractVector{UInt8}, crc::UInt32=0x00000000)
     # use block size 24576=8192*3, since that is the threshold for
     # 3-way parallel SIMD code in the underlying jl_crc32 C function.
-    last::Int64 = lastindex(a)
-    nb::Int64 = length(a)
+    last::Int = lastindex(a)
+    nb::Int = length(a)
     buf = Vector{UInt8}(undef, min(nb, 24576))
     while nb > 0
         n = min(nb, 24576)

--- a/src/CRC32.jl
+++ b/src/CRC32.jl
@@ -30,7 +30,7 @@ end
     crc32(data, crc::UInt32=0x00000000)
 
 Compute the CRC-32 checksum (ISO 3309, ITU-T V.42, CRC-32-IEEE) of the given `data`, which can be
-an `Array{UInt8}`, a contiguous subarray thereof, a `AbstractVector{UInt8}`, or a `String`.
+an `Array{UInt8}`, a contiguous subarray thereof, an `AbstractVector{UInt8}`, or a `String`.
 Optionally, you can pass a starting `crc` integer to be mixed in with the checksum.
 The `crc` parameter can be used to compute a checksum on data divided into chunks: performing
 `crc32(data2, crc32(data1))` is equivalent to the checksum of `[data1; data2]`.

--- a/src/CRC32.jl
+++ b/src/CRC32.jl
@@ -78,8 +78,8 @@ end
 function _crc32(a::AbstractVector{UInt8}, crc::UInt32=0x00000000)
     # use block size 24576=8192*3, since that is the threshold for
     # 3-way parallel SIMD code in the underlying jl_crc32 C function.
-    last::Int = lastindex(a)
-    nb::Int = length(a)
+    last = lastindex(a)
+    nb = length(a)
     buf = Vector{UInt8}(undef, min(nb, 24576))
     while nb > 0
         n = min(nb, 24576)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using CRC32
 using Test
+using OffsetArrays: Origin
 
 # based on julia/stdlib/CRC32/test/runtests.jl
 
@@ -9,6 +10,12 @@ using Test
         s = String(UInt8[1:n;])
         ss = SubString(String(UInt8[0:(n+1);]), 2:(n+1))
         @test crc32(UInt8[1:n;]) == crc == crc32(s) == crc32(ss) == crc32(codeunits(s)) == crc32(codeunits(ss))
+        @test crc == crc32(UInt8(1):UInt8(n))
+        if VERSION ≥ v"1.11"
+            m = Memory{UInt8}(undef, n)
+            m .= 1:n
+            @test crc == crc32(m)
+        end
     end
 
     # test that crc parameter is equivalent to checksum of concatenated data,
@@ -59,4 +66,9 @@ using Test
     if Sys.WORD_SIZE == 64
         @test crc32(zeros(UInt8, 2^32)) == 0xd202ef8d #crc32(zeros(UInt8, 2^31), crc32(zeros(UInt8, 2^31)))
     end
+
+    # Test crc of AbstractVector{UInt8}
+    a = view(rand(UInt8, 300000), 1:2:300000)
+    @test crc32(a) == crc32(collect(a))
+    @test crc32(Origin(0)(b"hello")) == crc32(b"hello")
 end


### PR DESCRIPTION
This PR adds the new `Memory{UInt8}` type to the `ByteArray` union in Julia 1.11.

I also added a generic fallback method for `AbstractVector{UInt8}` similar to the existing generic `IO` method.